### PR TITLE
Allow nil predicates, matching all nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/bobg/htree/v2
 go 1.23
 
 require (
-	github.com/bobg/go-generics/v4 v4.1.1
+	github.com/bobg/go-generics/v4 v4.1.2
+	github.com/bobg/seqs v1.5.2
 	github.com/google/go-cmp v0.6.0
 	golang.org/x/net v0.34.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
-github.com/bobg/go-generics/v4 v4.1.1 h1:At0uu6D/VksvjPjxvYbWs3k4X1/aAFiTapr3kuiuuiM=
-github.com/bobg/go-generics/v4 v4.1.1/go.mod h1:Oj7bxNHiEkq1PaCYmVA/dduJOsFnPnGV93NTkSrASI0=
+github.com/bobg/go-generics/v4 v4.1.2 h1:iF62T5EypncG3kTYFTWzBgfZlwCgm84tUboY9TKZT+4=
+github.com/bobg/go-generics/v4 v4.1.2/go.mod h1:KVwpxEYErjvcqjJSJqVNZd/JEq3SsQzb9t01+82pZGw=
+github.com/bobg/seqs v1.5.2 h1:QXwmpT3tfMgdG1oPE4FvM2NAI3zAyuN1r+FA1hLmyE8=
+github.com/bobg/seqs v1.5.2/go.mod h1:Iw4ESqX24EovuZ+0UHrnPmHYK1UyO9jcAZpPIzlNMa0=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=

--- a/htree.go
+++ b/htree.go
@@ -18,7 +18,7 @@ type Seq = iter.Seq[*html.Node]
 // in a depth-first search of the given tree,
 // satisfying the given predicate.
 func Find(tree *html.Node, pred func(*html.Node) bool) *html.Node {
-	if pred(tree) {
+	if pred == nil || pred(tree) {
 		return tree
 	}
 	if tree.Type == html.TextNode {
@@ -88,7 +88,7 @@ func FindAll(tree *html.Node, pred func(*html.Node) bool) Seq {
 }
 
 func findAll(node *html.Node, pred func(*html.Node) bool, yield func(*html.Node) bool) bool {
-	if pred(node) {
+	if pred == nil || pred(node) {
 		return yield(node)
 	}
 	return findAllChildren(node, pred, yield)
@@ -144,7 +144,7 @@ func FindAllChildEls(node *html.Node, pred func(*html.Node) bool) Seq {
 // that is true only if the node has type `ElementNode` and passes the original predicate.
 func elPred(pred func(*html.Node) bool) func(*html.Node) bool {
 	return func(n *html.Node) bool {
-		return n.Type == html.ElementNode && pred(n)
+		return n.Type == html.ElementNode && (pred == nil || pred(n))
 	}
 }
 
@@ -217,7 +217,7 @@ func Text(node *html.Node) (string, error) {
 // minus any subnodes that cause the supplied predicate to return true.
 // If `node` itself is pruned, the return value is nil.
 func Prune(node *html.Node, pred func(*html.Node) bool) *html.Node {
-	if pred(node) {
+	if pred == nil || pred(node) {
 		return nil
 	}
 

--- a/htree_test.go
+++ b/htree_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bobg/seqs"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 )
@@ -65,6 +66,35 @@ func TestHTML(t *testing.T) {
 		if got != want {
 			t.Errorf("got %s, want %s", got, want)
 		}
+	})
+
+	t.Run("NilPred", func(t *testing.T) {
+		t.Run("NilPred", func(t *testing.T) {
+			el := FindEl(root, func(n *html.Node) bool {
+				return n.DataAtom == atom.Div && ElClassContains(n, "vector-main-menu")
+			})
+			if el == nil {
+				t.Fatal("no el")
+			}
+			got := FindEl(el, nil)
+			if got != el {
+				t.Errorf("got %v, want %v", got, el)
+			}
+
+			children := FindAllChildEls(el, nil)
+			gotClasses := slices.Collect(seqs.Map(children, func(n *html.Node) string {
+				return ElAttr(n, "class")
+			}))
+			wantClasses := []string{
+				"vector-pinnable-header vector-main-menu-pinnable-header vector-pinnable-header-unpinned",
+				"vector-menu mw-portlet mw-portlet-navigation",
+				"vector-menu mw-portlet mw-portlet-interaction",
+				"vector-main-menu-action vector-main-menu-action-lang-alert",
+			}
+			if !slices.Equal(gotClasses, wantClasses) {
+				t.Errorf("got %v, want %v", gotClasses, wantClasses)
+			}
+		})
 	})
 
 	t.Run("FindAllEls", func(t *testing.T) {


### PR DESCRIPTION
This PR adds the ability to specify `nil` as the value for any node predicate. It's equivalent to specifying

```go
func (*html.Node) bool { return true }
```